### PR TITLE
fix: exist with non-zero code on every error

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -62,4 +62,5 @@ try {
     }
 } catch (err) {
     console.error('Error:', chalk.red(err))
+    process.exit(1)
 }


### PR DESCRIPTION
Without this instruction it finishes with 0 error code even if an error was thrown. Such behaviour is dangerous, because the docker image build completes successfully, but there is no `yarn.lock` inside and it is unexpected.